### PR TITLE
JENKINS-11887 Support Trac+Git as repository browser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.398</version>
+    <version>1.399</version>
   </parent>
 
   <artifactId>trac</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.392</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.398</version>
   </parent>
 
   <artifactId>trac</artifactId>
@@ -159,6 +158,11 @@
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>subversion</artifactId>
       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <version>1.1.14</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
@@ -1,0 +1,104 @@
+package hudson.plugins.trac;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+import hudson.plugins.git.browser.GitRepositoryBrowser;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.EditType;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.SubversionRepositoryBrowser;
+import hudson.scm.browsers.QueryBuilder;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * {@link SubversionRepositoryBrowser} that produces Trac links.
+ */
+public class TracGitRepositoryBrowser extends GitRepositoryBrowser {
+    
+	private static final long serialVersionUID = 1L;
+
+    @DataBoundConstructor
+    public TracGitRepositoryBrowser() {
+    }
+
+    /**
+     * Gets a URL for the {@link TracProjectProperty#tracWebsite} value
+     * configured for the current project.
+     * 
+     * This function is protected to allow the test to override it
+     * and implement a Mock getTracWebURL function to make tests easy.
+     */
+    protected URL getTracWebURL(GitChangeSet changeSet) throws MalformedURLException {
+    	ChangeLogSet<?> cs = changeSet.getParent();
+        AbstractProject<?,?> p = (AbstractProject<?,?>)cs.build.getProject();
+        TracProjectProperty tpp = p.getProperty(TracProjectProperty.class);
+        if(tpp==null)   
+        	return null;
+        else
+        	return new URL(tpp.tracWebsite);
+    }
+
+    @Override
+    public URL getDiffLink(Path path) throws IOException {
+    	// normally the diffs of a changeset are shown on one Trac HTML page and use the pattern 
+    	// <url>"/changeset/"<changesetID>"#file"<NoOfFileInChangeset>
+    	// BUt because the git changeset doesn't return an order list (only a HashSet)
+    	// it is not possible to get correct index for the file inside the changeset
+    	
+    	// Therefore a different URL pattern is used to show only the diff of a single file. 
+    	// returns <url>"/changeset/"<changesetID>/<file>
+    	// The drawback is that the user has to navigate and not only to scroll to see other diffs.
+    	
+    	// Instead of https://fedorahosted.org/eclipse-fedorapackager/changeset/0956859f7db2656cae445488689a214c104bf1b3#file3
+    	// e.g.       https://fedorahosted.org/eclipse-fedorapackager/changeset/0956859f7db2656cae445488689a214c104bf1b3/org.fedoraproject.eclipse.packager.rpm/src/org/fedoraproject/eclipse/packager/rpm/internal/handlers/SRPMImportHandler.java
+        if (path.getEditType() == EditType.EDIT) {
+        	return new URL(getTracWebURL(path.getChangeSet()), getChangeSetLink(path.getChangeSet()).toString() + "/" + path.getPath() );            
+        }
+        return null;
+    }
+
+
+	@Override
+    public URL getFileLink(Path path) throws IOException {
+    	// returns <url>"/browser/"<file>"$rev="<changsetID>
+    	// e.g. https://fedorahosted.org/eclipse-fedorapackager/browser/org.fedoraproject.eclipse.packager.rpm/src/org/fedoraproject/eclipse/packager/rpm/RpmText.java?rev=0956859f7db2656cae445488689a214c104bf1b3
+        String spec;
+        URL url = getTracWebURL(path.getChangeSet());
+        if (path.getEditType() == EditType.DELETE) {
+        	spec = new QueryBuilder(url.getQuery()).add("rev="+path.getChangeSet().getParentCommit()).toString();
+        } else {
+        	spec = new QueryBuilder(url.getQuery()).add("rev="+path.getChangeSet().getId()).toString();
+        }
+        return new URL(url, url.getPath() + "browser/" + path.getPath() + spec);
+    }
+
+    @Override
+    public URL getChangeSetLink(GitChangeSet changeSet) throws IOException {
+    	// returns <url>"/changeset/"<changsetID>
+    	// e.g. https://fedorahosted.org/eclipse-fedorapackager/changeset/0956859f7db2656cae445488689a214c104bf1b3
+        URL url = getTracWebURL(changeSet);
+        return new URL(url, url.getPath() + "changeset/" + changeSet.getId());
+    }
+
+    
+    
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
+        public DescriptorImpl() {
+            super(TracGitRepositoryBrowser.class);
+        }
+
+        public String getDisplayName() {
+            return "TracGit";
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
@@ -9,7 +9,6 @@ import hudson.plugins.git.browser.GitRepositoryBrowser;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.EditType;
 import hudson.scm.RepositoryBrowser;
-import hudson.scm.SubversionRepositoryBrowser;
 import hudson.scm.browsers.QueryBuilder;
 
 import java.io.IOException;
@@ -19,7 +18,9 @@ import java.net.URL;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
- * {@link SubversionRepositoryBrowser} that produces Trac links.
+ * {@link GitRepositoryBrowser} that produces Trac links.
+ * 
+ *  @author Gerd Zanker (gerd.zanker@web.de)
  */
 public class TracGitRepositoryBrowser extends GitRepositoryBrowser {
     
@@ -48,14 +49,15 @@ public class TracGitRepositoryBrowser extends GitRepositoryBrowser {
 
     @Override
     public URL getDiffLink(Path path) throws IOException {
-    	// normally the diffs of a changeset are shown on one Trac HTML page and use the pattern 
-    	// <url>"/changeset/"<changesetID>"#file"<NoOfFileInChangeset>
-    	// BUt because the git changeset doesn't return an order list (only a HashSet)
-    	// it is not possible to get correct index for the file inside the changeset
-    	
+    	// Normally the diffs of a changeset are shown on one single Trac HTML page 
+    	// and use the pattern <url>"/changeset/"<changesetID>"#file"<NoOfFileInChangeset>
+    	// But because the git changeset doesn't return an order list (only a HashSet)
+    	// it is not possible to get correct index for the file inside the changeset.
+    	// see https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitChangeSet.java#L57
+    	    	
     	// Therefore a different URL pattern is used to show only the diff of a single file. 
     	// returns <url>"/changeset/"<changesetID>/<file>
-    	// The drawback is that the user has to navigate and not only to scroll to see other diffs.
+    	// The drawback is 'only' that the user has to navigate and not only to scroll to see other diffs.
     	
     	// Instead of https://fedorahosted.org/eclipse-fedorapackager/changeset/0956859f7db2656cae445488689a214c104bf1b3#file3
     	// e.g.       https://fedorahosted.org/eclipse-fedorapackager/changeset/0956859f7db2656cae445488689a214c104bf1b3/org.fedoraproject.eclipse.packager.rpm/src/org/fedoraproject/eclipse/packager/rpm/internal/handlers/SRPMImportHandler.java
@@ -64,7 +66,6 @@ public class TracGitRepositoryBrowser extends GitRepositoryBrowser {
         }
         return null;
     }
-
 
 	@Override
     public URL getFileLink(Path path) throws IOException {

--- a/src/main/resources/hudson/plugins/trac/TracGitRepositoryBrowser/config.jelly
+++ b/src/main/resources/hudson/plugins/trac/TracGitRepositoryBrowser/config.jelly
@@ -1,0 +1,1 @@
+<j:jelly xmlns:j="jelly:core"/>

--- a/src/test/java/hudson/plugins/trac/TracGitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/trac/TracGitRepositoryBrowserTest.java
@@ -17,6 +17,8 @@ import junit.framework.TestCase;
 import org.xml.sax.SAXException;
 
 /**
+ * Tests for TracGitRepositoryBrowser 
+ * 
  * @author Gerd Zanker (gerd.zanker@web.de)
  * 
  * Based on the ViewGetWeb code from
@@ -24,9 +26,17 @@ import org.xml.sax.SAXException;
  */
 public class TracGitRepositoryBrowserTest extends TestCase {
 
+	/** 
+	 * URL used for testing
+	 */
 	private static final String TRAC_URL = "https://trac";
-    private final TracGitRepositoryBrowser tracGitBrowser = new TracGitRepositoryBrowserMock();
-
+	
+    /**
+     * TracGitRepositoryBrowser instance used for testing.
+     * The getTracWebURL function is mocked to easily return the testing URL. 
+     */
+	private final TracGitRepositoryBrowser tracGitBrowser = new TracGitRepositoryBrowserMock();
+    
     /**
      * Mock implementation to return the test URL.
      */
@@ -57,8 +67,7 @@ public class TracGitRepositoryBrowserTest extends TestCase {
     /**
      * Test method for
      * {@link hudson.plugins.git.browser.TracGitBrowser#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
-     * Test cases where links are tested, leading to the same changeset page as above, but using anchors.
-     * The anchors are the diff sections for each file inside the changeset.
+     * Test cases where links are tested, leading to the diff of the file from the same changeset page as above.
      * 
      * @throws SAXException
      * @throws IOException
@@ -123,7 +132,14 @@ public class TracGitRepositoryBrowserTest extends TestCase {
     }
     
     
-
+    /**
+     * Helper to create a changeset for testing.
+     * 
+     * @param rawchangelogpath
+     * @return
+     * @throws IOException
+     * @throws SAXException
+     */
     private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
         final File rawchangelog = new File(TracGitRepositoryBrowserTest.class.getResource(rawchangelogpath).getFile());
         final GitChangeLogParser logParser = new GitChangeLogParser(false);
@@ -132,6 +148,14 @@ public class TracGitRepositoryBrowserTest extends TestCase {
     }
 
 
+    /**
+     * Helper to create a map of paths.
+     * 
+     * @param changelog
+     * @return
+     * @throws IOException
+     * @throws SAXException
+     */
     private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
         final HashMap<String, Path> pathMap = new HashMap<String, Path>();
         final Collection<Path> changeSet = createChangeSet(changelog).getPaths();

--- a/src/test/java/hudson/plugins/trac/TracGitRepositoryBrowserTest.java
+++ b/src/test/java/hudson/plugins/trac/TracGitRepositoryBrowserTest.java
@@ -1,0 +1,144 @@
+package hudson.plugins.trac;
+
+import hudson.plugins.git.GitChangeLogParser;
+import hudson.plugins.git.GitChangeSet;
+import hudson.plugins.git.GitChangeSet.Path;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.xml.sax.SAXException;
+
+/**
+ * @author Gerd Zanker (gerd.zanker@web.de)
+ * 
+ * Based on the ViewGetWeb code from
+ * @author Paul Nyheim (paul.nyheim@gmail.com)
+ */
+public class TracGitRepositoryBrowserTest extends TestCase {
+
+	private static final String TRAC_URL = "https://trac";
+    private final TracGitRepositoryBrowser tracGitBrowser = new TracGitRepositoryBrowserMock();
+
+    /**
+     * Mock implementation to return the test URL.
+     */
+    private class TracGitRepositoryBrowserMock extends TracGitRepositoryBrowser {
+        private static final long serialVersionUID = 1L;
+
+		@Override
+		protected URL getTracWebURL(GitChangeSet changeSet) throws MalformedURLException {
+        	return new URL(TRAC_URL);
+	    }
+	}
+
+
+        
+    /**
+     * Test method for
+     * {@link hudson.plugins.git.browser.TracGitBrowser#getChangeSetLink(hudson.plugins.git.GitChangeSet)}.
+     * Test case where a simple link to a changeset is build.
+     * 
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetChangeSetLinkGitChangeSet() throws IOException, SAXException {
+        final URL changeSetLink = tracGitBrowser.getChangeSetLink(createChangeSet("rawchangelog"));
+        assertEquals(TRAC_URL+"/changeset/396fc230a3db05c427737aa5c2eb7856ba72b05d", changeSetLink.toString());
+    }
+
+    /**
+     * Test method for
+     * {@link hudson.plugins.git.browser.TracGitBrowser#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Test cases where links are tested, leading to the same changeset page as above, but using anchors.
+     * The anchors are the diff sections for each file inside the changeset.
+     * 
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetDiffLinkPath() throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
+        final Path path1 = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        assertEquals(TRAC_URL + "/changeset/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/main/java/hudson/plugins/git/browser/GithubWeb.java", tracGitBrowser.getDiffLink(path1).toString());
+        final Path path2 = pathMap.get("src/test/java/hudson/plugins/git/browser/GithubWebTest.java");
+        assertEquals(TRAC_URL + "/changeset/396fc230a3db05c427737aa5c2eb7856ba72b05d/src/test/java/hudson/plugins/git/browser/GithubWebTest.java", tracGitBrowser.getDiffLink(path2).toString());
+        final Path path3 = pathMap.get("src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file");
+        assertNull("Do not return a diff link for added files.", tracGitBrowser.getDiffLink(path3));
+    }
+
+    /**
+     * Test method for
+     * {@link hudson.plugins.git.browser.TracGitBrowser#getDiffLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Special test cases for a diff of a deleted file. 
+     * Here no diff is available and therefore the test checks for null. 
+     * 
+     * @throws SAXException
+     * @throws IOException
+     */
+   public void testGetDiffLinkForDeletedFile() throws Exception{
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
+        final Path path = pathMap.get("bar");
+        assertNull("Do not return a diff link for deleted files.", tracGitBrowser.getDiffLink(path));
+
+    }
+    
+    /**
+     * Test method for
+     * {@link hudson.plugins.git.browser.TracGitBrowser#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Test case for a link to a file of one dedicated revision, derived from changeset
+     * 
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetFileLinkPath() throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog");
+        final Path path = pathMap.get("src/main/java/hudson/plugins/git/browser/GithubWeb.java");
+        final URL fileLink = tracGitBrowser.getFileLink(path);
+        assertEquals(TRAC_URL + "/browser/src/main/java/hudson/plugins/git/browser/GithubWeb.java?rev=396fc230a3db05c427737aa5c2eb7856ba72b05d",
+                String.valueOf(fileLink));
+    }
+    
+    /**
+     * Test method for
+     * {@link hudson.plugins.git.browser.TracGitBrowser#getFileLink(hudson.plugins.git.GitChangeSet.Path)}.
+     * Special test case for a link to a deleted file of one dedicated revision, derived from changeset.
+     * Here the changeset doesn't have the right ID, because the parent changeset ID must be used
+     * to link to the last possible revision.
+     * 
+     * @throws SAXException
+     * @throws IOException
+     */
+    public void testGetFileLinkPathForDeletedFile() throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = createPathMap("rawchangelog-with-deleted-file");
+        final Path path = pathMap.get("bar");
+        final URL fileLink = tracGitBrowser.getFileLink(path);
+        assertEquals(TRAC_URL + "/browser/bar?rev=b547aa10c3f06710c6fdfcdb2a9149c81662923b", String.valueOf(fileLink));
+    }
+    
+    
+
+    private GitChangeSet createChangeSet(String rawchangelogpath) throws IOException, SAXException {
+        final File rawchangelog = new File(TracGitRepositoryBrowserTest.class.getResource(rawchangelogpath).getFile());
+        final GitChangeLogParser logParser = new GitChangeLogParser(false);
+        final List<GitChangeSet> changeSetList = logParser.parse(null, rawchangelog).getLogs();
+        return changeSetList.get(0);
+    }
+
+
+    private HashMap<String, Path> createPathMap(final String changelog) throws IOException, SAXException {
+        final HashMap<String, Path> pathMap = new HashMap<String, Path>();
+        final Collection<Path> changeSet = createChangeSet(changelog).getPaths();
+        for (final Path path : changeSet) {
+            pathMap.put(path.getPath(), path);
+        }
+        return pathMap;
+    }
+
+}

--- a/src/test/resources/hudson/plugins/trac/rawchangelog
+++ b/src/test/resources/hudson/plugins/trac/rawchangelog
@@ -1,0 +1,11 @@
+commit 396fc230a3db05c427737aa5c2eb7856ba72b05d
+tree 196333547f8b9a5fcc8b1fffe4accb01da42c5a6
+parent f28f125f4cc3e5f6a32daee6a26f36f7b788b8ff
+author Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277411790 +0200
+committer Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277411790 +0200
+
+    Github seems to have no URL for deleted files, so just return a difflink instead.
+
+:100644 100644 3f28ad75f5ecd5e0ea9659362e2eef18951bd451 2e0756cd853dccac638486d6aab0e74bc2ef4041 M	src/main/java/hudson/plugins/git/browser/GithubWeb.java
+:100644 100644 019d377767702b6c572fa4ae97c982e02dcd76ff 7c89764ba7a51c23e809b24376d90d7d06337434 M	src/test/java/hudson/plugins/git/browser/GithubWebTest.java
+:000000 100644 0000000000000000000000000000000000000000 885ce99421b3ae3a413a5c7fb0cdf9ec477d3f64 A	src/test/resources/hudson/plugins/git/browser/rawchangelog-with-deleted-file

--- a/src/test/resources/hudson/plugins/trac/rawchangelog-with-deleted-file
+++ b/src/test/resources/hudson/plugins/trac/rawchangelog-with-deleted-file
@@ -1,0 +1,9 @@
+commit fc029da233f161c65eb06d0f1ed4f36ae81d1f4f
+tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent b547aa10c3f06710c6fdfcdb2a9149c81662923b
+author Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277410107 +0200
+committer Mirko Friedenhagen <mfriedenhagen@dev.java.net> 1277410107 +0200
+
+    Delete file
+
+:100644 000000 257cc5642cb1a054f08cc83f2d943e56fd3ebe99 0000000000000000000000000000000000000000 D	bar


### PR DESCRIPTION
This Trac-plugin code supports "TracGit" for the "Repository browser" setting. The given Trac URL at the top of the job settings will be used to generate links for git changesets, files and diffs to your Trac "Browse Source" area.
https://issues.jenkins-ci.org/browse/JENKINS-11887
