### PR TITLE
Jenkins-12588 optional git-plugin dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>git</artifactId>
       <version>1.1.14</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/trac/TracGitRepositoryBrowser.java
@@ -3,6 +3,7 @@ package hudson.plugins.trac;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
+import hudson.model.Hudson;
 import hudson.plugins.git.GitChangeSet;
 import hudson.plugins.git.GitChangeSet.Path;
 import hudson.plugins.git.browser.GitRepositoryBrowser;
@@ -91,10 +92,10 @@ public class TracGitRepositoryBrowser extends GitRepositoryBrowser {
 
     
     
-    @Extension
+    @Extension(optional = true)
     public static final class DescriptorImpl extends Descriptor<RepositoryBrowser<?>> {
         public DescriptorImpl() {
-            super(TracGitRepositoryBrowser.class);
+        	super();
         }
 
         public String getDisplayName() {


### PR DESCRIPTION
The trac-plugin supports now subversion repository browsing and also git repository browsing when the git-plugin is installed.
